### PR TITLE
Faster Kernel 12 with stmatrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,15 @@
 NVCC_FLAGS = -std=c++17 -O3 -DNDEBUG -w
 NVCC_LDFLAGS = -lcublas -lcuda
-NVCC_INCLUDES = -I/usr/local/cuda-12.6/include
-NVCC_LDLIBS =
-NCLL_INCUDES =
 OUT_DIR = out
-
-GPU_COMPUTE_CAPABILITY=$(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader | sed 's/\.//g' | sort -n | head -n 1)
-GPU_COMPUTE_CAPABILITY := $(strip $(GPU_COMPUTE_CAPABILITY))
-# if GPU_COMPUTE_CAPABILITY = 90, set it to 90a
-GPU_COMPUTE_CAPABILITY := $(if $(findstring 90,$(GPU_COMPUTE_CAPABILITY)),90a,$(GPU_COMPUTE_CAPABILITY))
 
 CUDA_OUTPUT_FILE = -o $(OUT_DIR)/$@
 NCU_PATH := $(shell which ncu)
 NCU_COMMAND = sudo $(NCU_PATH) --set full --import-source yes
 
 NVCC_FLAGS += --expt-relaxed-constexpr --expt-extended-lambda --use_fast_math -Xcompiler=-fPIE -Xcompiler=-Wno-psabi -Xcompiler=-fno-strict-aliasing
-# NVCC_FLAGS += --generate-code arch=compute_$(GPU_COMPUTE_CAPABILITY),code=[compute_$(GPU_COMPUTE_CAPABILITY),sm_$(GPU_COMPUTE_CAPABILITY)]
-# NVCC_FLAGS += --ptxas-options=-v #,--register-usage-level=10
-# NVCC_FLAGS += -gencode arch=compute_90a,code=sm_90a -Xnvlink=--verbose -Xptxas=--verbose -Xptxas=--warn-on-spills
 NVCC_FLAGS += -arch=sm_90a
 
-NVCC_BASE = nvcc $(NVCC_FLAGS) $(NVCC_LDFLAGS) -lineinfo $(NVCC_INCLUDES) $(NVCC_LDLIBS)
+NVCC_BASE = nvcc $(NVCC_FLAGS) $(NVCC_LDFLAGS) -lineinfo
 
 sum: sum.cu 
 	$(NVCC_BASE) $^ $(CUDA_OUTPUT_FILE)
@@ -29,6 +18,7 @@ sumprofile: sum
 	$(NCU_COMMAND) -o $@ -f $(OUT_DIR)/$^
 
 matmul: matmul.cu 
+	mkdir -p $(OUT_DIR)
 	$(NVCC_BASE) $^ $(CUDA_OUTPUT_FILE)
 
 matmulprofile: matmul

--- a/examples/matmul/matmul_12.cuh
+++ b/examples/matmul/matmul_12.cuh
@@ -1,0 +1,638 @@
+
+namespace M12 {
+
+__device__ static inline uint64_t matrix_descriptor_encode(uint64_t x) {
+    return (((x) & 0x3FFFF) >> 0x4);
+}
+
+// Descriptor for a shared memory matrix.
+// Implementation is derived from PTX guide: https://docs.nvidia.com/cuda/parallel-thread-execution/#matrix-descriptor-format
+__device__ uint64_t make_smem_desc(bf16* ptr) {
+    // Convert shared memory pointer to integer
+    uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(ptr));
+    uint64_t desc = matrix_descriptor_encode(addr);
+    desc |= matrix_descriptor_encode((uint64_t)16) << 16;
+    desc |= matrix_descriptor_encode((uint64_t)1024) << 32;
+    desc |= 1llu << 62; // 128B swizzle
+    return desc;
+}
+
+__device__ void warpgroup_arrive() {
+    asm volatile("wgmma.fence.sync.aligned;\n" ::: "memory");
+}
+
+__device__ void warpgroup_commit_batch() {
+    asm volatile("wgmma.commit_group.sync.aligned;\n" ::: "memory");
+}
+
+__device__ void warpgroup_wait() {
+    asm volatile("wgmma.wait_group.sync.aligned 0;\n" ::: "memory");
+}
+
+template <int BlockMajorSize, int BlockMinorSize, bool swizzle=true>
+__host__ static inline CUtensorMap create_tensor_map(bf16* gmem_ptr, int global_height, int global_width) {
+    CUtensorMap tma_map;
+    void* gmem_address = (void*)gmem_ptr;
+    static_assert(BlockMinorSize >= 64);
+    assert(global_width % 64 == 0);
+    uint64_t gmem_prob_shape[5] = {64, (uint64_t)global_height, (uint64_t)global_width/64, 1, 1};
+    uint64_t gmem_prob_stride[5] = {sizeof(bf16) * global_width, 64*sizeof(bf16), 0, 0, 0};
+    uint32_t smem_box_shape[5] = {64, uint32_t(BlockMajorSize), uint32_t(BlockMinorSize/64), 1, 1};
+    uint32_t smem_box_stride[5] = {1, 1, 1, 1, 1};
+
+    CUresult result = cuTensorMapEncodeTiled(
+        &tma_map, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 3, gmem_address, gmem_prob_shape,
+        gmem_prob_stride, smem_box_shape, smem_box_stride, CU_TENSOR_MAP_INTERLEAVE_NONE,
+        swizzle ? CU_TENSOR_MAP_SWIZZLE_128B : CU_TENSOR_MAP_SWIZZLE_NONE, CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+
+    assert(result == CUDA_SUCCESS);
+    return tma_map;
+}
+
+CUtensorMap d_tma_map_A;
+CUtensorMap d_tma_map_B;
+CUtensorMap d_tma_map_C;
+int _prev_m=0, _prev_n=0, _prev_k=0;
+
+template<int ScaleD, int ScaleA, int ScaleB, int TransA, int TransB>
+__device__ __forceinline__ void wgmma256(float d[16][8], bf16* sA, bf16* sB) {
+    uint64_t desc_a = make_smem_desc(&sA[0]);
+    uint64_t desc_b = make_smem_desc(&sB[0]);
+    asm volatile(
+        "{\n"
+        "wgmma.mma_async.sync.aligned.m64n256k16.f32.bf16.bf16 "
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7,   "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15,  "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23,  "
+        " %24,  %25,  %26,  %27,  %28,  %29,  %30,  %31,  "
+        " %32,  %33,  %34,  %35,  %36,  %37,  %38,  %39,  "
+        " %40,  %41,  %42,  %43,  %44,  %45,  %46,  %47,  "
+        " %48,  %49,  %50,  %51,  %52,  %53,  %54,  %55,  "
+        " %56,  %57,  %58,  %59,  %60,  %61,  %62,  %63,  "
+        " %64,  %65,  %66,  %67,  %68,  %69,  %70,  %71,  "
+        " %72,  %73,  %74,  %75,  %76,  %77,  %78,  %79,  "
+        " %80,  %81,  %82,  %83,  %84,  %85,  %86,  %87,  "
+        " %88,  %89,  %90,  %91,  %92,  %93,  %94,  %95,  "
+        " %96,  %97,  %98,  %99,  %100, %101, %102, %103,  "
+        " %104, %105, %106, %107, %108, %109, %110, %111,  "
+        " %112, %113, %114, %115, %116, %117, %118, %119,  "
+        " %120, %121, %122, %123, %124, %125, %126, %127},"
+        " %128,"
+        " %129,"
+        " %130,    %131,  %132,  %133,  %134;\n"
+        "}\n"
+        :   "+f"(d[0][0]), "+f"(d[0][1]), "+f"(d[0][2]), "+f"(d[0][3]), "+f"(d[0][4]), "+f"(d[0][5]), "+f"(d[0][6]), "+f"(d[0][7]),
+            "+f"(d[1][0]), "+f"(d[1][1]), "+f"(d[1][2]), "+f"(d[1][3]), "+f"(d[1][4]), "+f"(d[1][5]), "+f"(d[1][6]), "+f"(d[1][7]),
+            "+f"(d[2][0]), "+f"(d[2][1]), "+f"(d[2][2]), "+f"(d[2][3]), "+f"(d[2][4]), "+f"(d[2][5]), "+f"(d[2][6]), "+f"(d[2][7]),
+            "+f"(d[3][0]), "+f"(d[3][1]), "+f"(d[3][2]), "+f"(d[3][3]), "+f"(d[3][4]), "+f"(d[3][5]), "+f"(d[3][6]), "+f"(d[3][7]),
+            "+f"(d[4][0]), "+f"(d[4][1]), "+f"(d[4][2]), "+f"(d[4][3]), "+f"(d[4][4]), "+f"(d[4][5]), "+f"(d[4][6]), "+f"(d[4][7]),
+            "+f"(d[5][0]), "+f"(d[5][1]), "+f"(d[5][2]), "+f"(d[5][3]), "+f"(d[5][4]), "+f"(d[5][5]), "+f"(d[5][6]), "+f"(d[5][7]),
+            "+f"(d[6][0]), "+f"(d[6][1]), "+f"(d[6][2]), "+f"(d[6][3]), "+f"(d[6][4]), "+f"(d[6][5]), "+f"(d[6][6]), "+f"(d[6][7]),
+            "+f"(d[7][0]), "+f"(d[7][1]), "+f"(d[7][2]), "+f"(d[7][3]), "+f"(d[7][4]), "+f"(d[7][5]), "+f"(d[7][6]), "+f"(d[7][7]),
+            "+f"(d[8][0]), "+f"(d[8][1]), "+f"(d[8][2]), "+f"(d[8][3]), "+f"(d[8][4]), "+f"(d[8][5]), "+f"(d[8][6]), "+f"(d[8][7]),
+            "+f"(d[9][0]), "+f"(d[9][1]), "+f"(d[9][2]), "+f"(d[9][3]), "+f"(d[9][4]), "+f"(d[9][5]), "+f"(d[9][6]), "+f"(d[9][7]),
+            "+f"(d[10][0]), "+f"(d[10][1]), "+f"(d[10][2]), "+f"(d[10][3]), "+f"(d[10][4]), "+f"(d[10][5]), "+f"(d[10][6]), "+f"(d[10][7]),
+            "+f"(d[11][0]), "+f"(d[11][1]), "+f"(d[11][2]), "+f"(d[11][3]), "+f"(d[11][4]), "+f"(d[11][5]), "+f"(d[11][6]), "+f"(d[11][7]),
+            "+f"(d[12][0]), "+f"(d[12][1]), "+f"(d[12][2]), "+f"(d[12][3]), "+f"(d[12][4]), "+f"(d[12][5]), "+f"(d[12][6]), "+f"(d[12][7]),
+            "+f"(d[13][0]), "+f"(d[13][1]), "+f"(d[13][2]), "+f"(d[13][3]), "+f"(d[13][4]), "+f"(d[13][5]), "+f"(d[13][6]), "+f"(d[13][7]),
+            "+f"(d[14][0]), "+f"(d[14][1]), "+f"(d[14][2]), "+f"(d[14][3]), "+f"(d[14][4]), "+f"(d[14][5]), "+f"(d[14][6]), "+f"(d[14][7]),
+            "+f"(d[15][0]), "+f"(d[15][1]), "+f"(d[15][2]), "+f"(d[15][3]), "+f"(d[15][4]), "+f"(d[15][5]), "+f"(d[15][6]), "+f"(d[15][7])
+        : "l"(desc_a), "l"(desc_b), "n"(int32_t(ScaleD)), "n"(int32_t(ScaleA)),
+            "n"(int32_t(ScaleB)), "n"(int32_t(TransA)), "n"(int32_t(TransB)));
+}
+
+template<int ScaleD, int ScaleA, int ScaleB, int TransA, int TransB>
+__device__ __forceinline__ void wgmma192(float d[12][8], bf16* sA, bf16* sB) {
+    uint64_t desc_a = make_smem_desc(&sA[0]);
+    uint64_t desc_b = make_smem_desc(&sB[0]);
+    asm volatile(
+        "{\n"
+        "wgmma.mma_async.sync.aligned.m64n192k16.f32.bf16.bf16 "
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7,   "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15,  "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23,  "
+        " %24,  %25,  %26,  %27,  %28,  %29,  %30,  %31,  "
+        " %32,  %33,  %34,  %35,  %36,  %37,  %38,  %39,  "
+        " %40,  %41,  %42,  %43,  %44,  %45,  %46,  %47,  "
+        " %48,  %49,  %50,  %51,  %52,  %53,  %54,  %55,  "
+        " %56,  %57,  %58,  %59,  %60,  %61,  %62,  %63,  "
+        " %64,  %65,  %66,  %67,  %68,  %69,  %70,  %71,  "
+        " %72,  %73,  %74,  %75,  %76,  %77,  %78,  %79,  "
+        " %80,  %81,  %82,  %83,  %84,  %85,  %86,  %87,  "
+        " %88,  %89,  %90,  %91,  %92,  %93,  %94,  %95},  "
+        " %96,"
+        " %97,"
+        " %98,    %99,  %100,  %101,  %102;\n"
+        "}\n"
+        :   "+f"(d[0][0]), "+f"(d[0][1]), "+f"(d[0][2]), "+f"(d[0][3]), "+f"(d[0][4]), "+f"(d[0][5]), "+f"(d[0][6]), "+f"(d[0][7]),
+            "+f"(d[1][0]), "+f"(d[1][1]), "+f"(d[1][2]), "+f"(d[1][3]), "+f"(d[1][4]), "+f"(d[1][5]), "+f"(d[1][6]), "+f"(d[1][7]),
+            "+f"(d[2][0]), "+f"(d[2][1]), "+f"(d[2][2]), "+f"(d[2][3]), "+f"(d[2][4]), "+f"(d[2][5]), "+f"(d[2][6]), "+f"(d[2][7]),
+            "+f"(d[3][0]), "+f"(d[3][1]), "+f"(d[3][2]), "+f"(d[3][3]), "+f"(d[3][4]), "+f"(d[3][5]), "+f"(d[3][6]), "+f"(d[3][7]),
+            "+f"(d[4][0]), "+f"(d[4][1]), "+f"(d[4][2]), "+f"(d[4][3]), "+f"(d[4][4]), "+f"(d[4][5]), "+f"(d[4][6]), "+f"(d[4][7]),
+            "+f"(d[5][0]), "+f"(d[5][1]), "+f"(d[5][2]), "+f"(d[5][3]), "+f"(d[5][4]), "+f"(d[5][5]), "+f"(d[5][6]), "+f"(d[5][7]),
+            "+f"(d[6][0]), "+f"(d[6][1]), "+f"(d[6][2]), "+f"(d[6][3]), "+f"(d[6][4]), "+f"(d[6][5]), "+f"(d[6][6]), "+f"(d[6][7]),
+            "+f"(d[7][0]), "+f"(d[7][1]), "+f"(d[7][2]), "+f"(d[7][3]), "+f"(d[7][4]), "+f"(d[7][5]), "+f"(d[7][6]), "+f"(d[7][7]),
+            "+f"(d[8][0]), "+f"(d[8][1]), "+f"(d[8][2]), "+f"(d[8][3]), "+f"(d[8][4]), "+f"(d[8][5]), "+f"(d[8][6]), "+f"(d[8][7]),
+            "+f"(d[9][0]), "+f"(d[9][1]), "+f"(d[9][2]), "+f"(d[9][3]), "+f"(d[9][4]), "+f"(d[9][5]), "+f"(d[9][6]), "+f"(d[9][7]),
+            "+f"(d[10][0]), "+f"(d[10][1]), "+f"(d[10][2]), "+f"(d[10][3]), "+f"(d[10][4]), "+f"(d[10][5]), "+f"(d[10][6]), "+f"(d[10][7]),
+            "+f"(d[11][0]), "+f"(d[11][1]), "+f"(d[11][2]), "+f"(d[11][3]), "+f"(d[11][4]), "+f"(d[11][5]), "+f"(d[11][6]), "+f"(d[11][7])
+        : "l"(desc_a), "l"(desc_b), "n"(int32_t(ScaleD)), "n"(int32_t(ScaleA)),
+            "n"(int32_t(ScaleB)), "n"(int32_t(TransA)), "n"(int32_t(TransB)));
+}
+
+
+template<int ScaleD, int ScaleA, int ScaleB, int TransA, int TransB>
+__device__ __forceinline__ void wgmma128(float d[8][8], bf16* sA, bf16* sB) {
+    uint64_t desc_a = make_smem_desc(&sA[0]);
+    uint64_t desc_b = make_smem_desc(&sB[0]);
+    asm volatile(
+        "{\n"
+        "wgmma.mma_async.sync.aligned.m64n128k16.f32.bf16.bf16 "
+        "{%0,   %1,   %2,   %3,   %4,   %5,   %6,   %7,   "
+        " %8,   %9,   %10,  %11,  %12,  %13,  %14,  %15,  "
+        " %16,  %17,  %18,  %19,  %20,  %21,  %22,  %23,  "
+        " %24,  %25,  %26,  %27,  %28,  %29,  %30,  %31,  "
+        " %32,  %33,  %34,  %35,  %36,  %37,  %38,  %39,  "
+        " %40,  %41,  %42,  %43,  %44,  %45,  %46,  %47,  "
+        " %48,  %49,  %50,  %51,  %52,  %53,  %54,  %55,  "
+        " %56,  %57,  %58,  %59,  %60,  %61,  %62,  %63},"
+        " %64,"
+        " %65,"
+        " %66,    %67,  %68,  %69,  %70;\n"
+        "}\n"
+        : "+f"(d[0][0]), "+f"(d[0][1]), "+f"(d[0][2]), "+f"(d[0][3]), "+f"(d[0][4]), "+f"(d[0][5]),
+            "+f"(d[0][6]), "+f"(d[0][7]), "+f"(d[1][0]), "+f"(d[1][1]), "+f"(d[1][2]), "+f"(d[1][3]),
+            "+f"(d[1][4]), "+f"(d[1][5]), "+f"(d[1][6]), "+f"(d[1][7]), "+f"(d[2][0]), "+f"(d[2][1]),
+            "+f"(d[2][2]), "+f"(d[2][3]), "+f"(d[2][4]), "+f"(d[2][5]), "+f"(d[2][6]), "+f"(d[2][7]),
+            "+f"(d[3][0]), "+f"(d[3][1]), "+f"(d[3][2]), "+f"(d[3][3]), "+f"(d[3][4]), "+f"(d[3][5]),
+            "+f"(d[3][6]), "+f"(d[3][7]), "+f"(d[4][0]), "+f"(d[4][1]), "+f"(d[4][2]), "+f"(d[4][3]),
+            "+f"(d[4][4]), "+f"(d[4][5]), "+f"(d[4][6]), "+f"(d[4][7]), "+f"(d[5][0]), "+f"(d[5][1]),
+            "+f"(d[5][2]), "+f"(d[5][3]), "+f"(d[5][4]), "+f"(d[5][5]), "+f"(d[5][6]), "+f"(d[5][7]),
+            "+f"(d[6][0]), "+f"(d[6][1]), "+f"(d[6][2]), "+f"(d[6][3]), "+f"(d[6][4]), "+f"(d[6][5]),
+            "+f"(d[6][6]), "+f"(d[6][7]), "+f"(d[7][0]), "+f"(d[7][1]), "+f"(d[7][2]), "+f"(d[7][3]),
+            "+f"(d[7][4]), "+f"(d[7][5]), "+f"(d[7][6]), "+f"(d[7][7])
+        : "l"(desc_a), "l"(desc_b), "n"(int32_t(ScaleD)), "n"(int32_t(ScaleA)),
+            "n"(int32_t(ScaleB)), "n"(int32_t(TransA)), "n"(int32_t(TransB)));
+}
+
+template<int WGMMA_N, int ScaleD, int ScaleA, int ScaleB, int TransA, int TransB>
+__device__ __forceinline__ void wgmma(float d[WGMMA_N/16][8], bf16* sA, bf16* sB) {
+    static_assert(WGMMA_N == 128 || WGMMA_N == 192 || WGMMA_N == 256);
+    if  constexpr (WGMMA_N == 256)
+        wgmma256<ScaleD, ScaleA, ScaleB, TransA, TransB>(d, sA, sB);
+    if  constexpr (WGMMA_N == 192)
+        wgmma192<ScaleD, ScaleA, ScaleB, TransA, TransB>(d, sA, sB);
+    if  constexpr (WGMMA_N == 128)
+        wgmma128<ScaleD, ScaleA, ScaleB, TransA, TransB>(d, sA, sB);
+}
+
+template <uint32_t RegCount>
+__device__ void warpgroup_reg_alloc() {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n" : : "n"(RegCount));
+}
+
+template <uint32_t RegCount>
+__device__ void warpgroup_reg_dealloc() {
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n" : : "n"(RegCount));
+}
+
+__device__ static __forceinline__ void init_barrier(uint64_t* bar, int thread_count, int transaction_count) {
+    uint32_t bar_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(bar)); 
+    asm volatile (
+        "mbarrier.init.shared::cta.b64 [%0], %1;\n"
+        :: "r"(bar_ptr), "r"(thread_count+transaction_count)
+    );
+}
+
+__device__ static __forceinline__ void expect_bytes(uint64_t* bar, uint32_t bytes) {
+    uint32_t bar_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(bar)); 
+    asm volatile ("mbarrier.arrive.expect_tx.shared::cta.b64 _, [%0], %1;\n"
+        :: "r"(bar_ptr), "r"(bytes));
+}
+
+__device__ static inline void load_async(bf16 *dst, void const* src_tma_map, uint64_t* bar, int global_col_idx, int global_row_idx) {
+    uint64_t tma_ptr  = reinterpret_cast<uint64_t>(src_tma_map);
+    uint32_t mbar_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(bar));
+    uint32_t dst_ptr  = static_cast<uint32_t>(__cvta_generic_to_shared(dst));
+
+    // We use 3d tiling to load from GMEM to SMEM. 2d tiling only works for tiles <= 64 columns.
+    // For larger tiles, we need 3d tiling:
+    // First dimension: 64 (columns)
+    // Second dimension: Row
+    // Third dimension: Column / 64
+    // I spent a lot of time figuring this out. Hope this gets documented at some point.
+    asm volatile (
+        "cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%3, %4, %5}], [%2];"
+        :
+        : "r"(dst_ptr), "l"(tma_ptr), "r"(mbar_ptr),
+        "n"(0), "r"(global_row_idx), "r"(global_col_idx/64)
+        : "memory"
+    );
+}
+
+__device__ static inline void store_async(void const* dst_tma_map, bf16 *src, int global_col_idx, int global_row_idx) {
+    uint64_t tma_ptr  = reinterpret_cast<uint64_t>(dst_tma_map);
+    uint32_t src_ptr  = static_cast<uint32_t>(__cvta_generic_to_shared(src));
+
+    asm volatile (
+        "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+        " [%0, {%2, %3, %4}], [%1];"
+        :
+        : "l"(tma_ptr), "r"(src_ptr),
+        "n"(0), "r"(global_row_idx), "r"(global_col_idx / 64)
+        : "memory"
+    );
+}
+
+__device__ static __forceinline__ void wait(uint64_t* bar, int kPhaseBit) {
+    uint32_t mbar_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(bar));
+    // Call mbarrier.try_wait in a while loop till it returns true.
+    asm volatile (
+        "{\n"
+        ".reg .pred                P1;\n"
+        "LAB_WAIT:\n"
+        "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1;\n"
+        "@P1                       bra.uni DONE;\n"
+        "bra.uni                   LAB_WAIT;\n"
+        "DONE:\n"
+        "}\n"
+        :: "r"(mbar_ptr),
+        "r"(kPhaseBit)
+    );
+}
+
+__device__ static __forceinline__ void arrive(uint64_t* bar, uint32_t count=1) {
+    uint32_t mbar_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(bar)); 
+    asm volatile (
+        "mbarrier.arrive.release.cta.shared::cta.b64 _, [%0], %1;\n"
+        :
+        : "r"(mbar_ptr), "r"(count)
+        : "memory"
+    );
+}
+
+__device__ void arrive_cluster(uint64_t* bar, uint32_t cta_id, uint32_t count=1) {
+    uint32_t smem_addr = static_cast<uint32_t>(__cvta_generic_to_shared(bar));
+    // Call arrive on barrier stored in SM number `cta_id`
+    // Use mapa.shared instruction to access other SM's barrier.
+    asm volatile(
+        "{\n"
+        ".reg .b32 remAddr32;\n"
+        "mapa.shared::cluster.u32  remAddr32, %0, %1;\n"
+        "mbarrier.arrive.shared::cluster.b64  _, [remAddr32], %2;\n"
+        "}"
+        :: "r"(smem_addr), "r"(cta_id), "r"(count));
+}
+
+__device__ static inline void load_async_multicast(bf16 *dst, void const* src_tma_map, uint64_t* bar, int global_col_idx, int global_row_idx, uint16_t cluster_mask) {
+    uint64_t tma_ptr  = reinterpret_cast<uint64_t>(src_tma_map);
+    uint32_t mbar_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(bar));
+    uint32_t dst_ptr  = static_cast<uint32_t>(__cvta_generic_to_shared(dst));
+
+    asm volatile (
+        "cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster"
+        " [%0], [%1, {%3, %4, %5}], [%2], %6;"
+        :
+        : "r"(dst_ptr), "l"(tma_ptr), "r"(mbar_ptr),
+        "n"(0), "r"(global_row_idx), "r"(global_col_idx/64), "h"(cluster_mask)
+        : "memory"
+    );
+}
+
+template<int BM, int BN, int B_WG_M, int WGMMA_M, int WGMMA_N>
+__device__ __forceinline__ void write_tile_tma(uint32_t base_addr, float *d, bf16* tma_src, void const* dst_tma_map, int m, int n, int tid, int wg_idx) {
+    if (m >= 0) {
+        bf16 d_bf16[8];
+        int4* data_ptr = (int4*)d_bf16;
+
+        for (int m_it = 0; m_it < B_WG_M/WGMMA_M; ++m_it) {
+            for (int w = 0; w < WGMMA_N; w+=16, d += 8) {
+                uint32_t addr = base_addr + (w*B_WG_M + m_it*WGMMA_M) * sizeof(bf16);
+                for (int k = 0; k < 8; k++) {
+                    d_bf16[k] = (bf16)(d[k]);
+                }
+                asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared::cta.b16 [%0], {%1, %2, %3, %4};"
+                             :: "r"(addr), "r"(data_ptr[0].x), "r"(data_ptr[0].y), "r"(data_ptr[0].z), "r"(data_ptr[0].w));
+            }
+        }
+        asm volatile("bar.sync %0, 128;\n" ::"r"(wg_idx + 2) : "memory");
+
+        if (tid == 0) {
+            store_async(dst_tma_map, tma_src, m*BM + wg_idx*B_WG_M, n*BN);
+            asm volatile("cp.async.bulk.commit_group;");
+        }
+    }
+}
+
+template<int VERSION, int NUM_SM, int BM, int BN, int TM, int TN>
+struct Schedule;
+
+constexpr int SPACE_LEN = 128;
+int *_dspace;
+
+template<int NUM_SM, int BM, int BN, int TM, int TN>
+struct Schedule<2, NUM_SM, BM, BN, TM, TN> {
+    int it;
+    int *space;
+
+    __device__ __forceinline__ Schedule(int M, int N, int block, int *_space) {
+        it = 0;
+        space = _space;
+    }
+
+    __device__ __forceinline__ bool next(int &block_m, int& block_n) {
+        if (it >= SPACE_LEN) {
+            return false;
+        }
+        int now = space[it];
+        if (now == -1) {
+            return false;
+        }
+        block_m = now >> 16;
+        block_n = (now & ((1<<16)-1));
+        ++it;
+        return true;
+    }
+};
+
+template <int BM, int BN, int BK, int QSIZE>
+struct SMem {
+    alignas(128) bf16 A[BM*BK*QSIZE];
+    alignas(128) bf16 B[BK*BN*QSIZE];
+    alignas(128) bf16 C[BN*BM];
+    alignas(8) uint64_t full[QSIZE], empty[QSIZE];
+    int space[SPACE_LEN];
+};
+
+template<int BM, int BN, int BK, int NUM_THREADS, int QSIZE, int NUM_SM, int CLUSTER_M, int CLUSTER_N>
+__global__  __launch_bounds__(NUM_THREADS) void  __cluster_dims__(CLUSTER_M * CLUSTER_N, 1, 1) matmulKernel11(int M, int N, int K, const __grid_constant__ CUtensorMap tensorMapC, const __grid_constant__ CUtensorMap tensorMapA, const __grid_constant__ CUtensorMap tensorMapB, int* dspace) {
+    constexpr int WGMMA_M = 64, WGMMA_K = 16, WGMMA_N=BN;
+    constexpr int num_consumers = (NUM_THREADS / 128) - 1;
+    constexpr int B_WG_M = BM / num_consumers;
+    constexpr int CLUSTERS = CLUSTER_M * CLUSTER_N;
+    assert((M / BM) % CLUSTER_M == 0);
+    assert((N / BN) % CLUSTER_N == 0);
+
+    extern __shared__ __align__(128) uint8_t smem[];
+    SMem<BM, BN, BK, QSIZE> &s = *reinterpret_cast<SMem<BM, BN, BK, QSIZE>*>(smem);
+    bf16 *sA = s.A, *sB = s.B, *sC = s.C;
+    uint64_t *full = s.full, *empty = s.empty;
+    int *space = s.space;
+
+    uint32_t rank;
+    asm volatile("mov.u32 %0, %clusterid.x;\n" : "=r"(rank) :);
+    // Load schedule for this SM
+    if (threadIdx.x < SPACE_LEN) space[threadIdx.x] = dspace[rank*SPACE_LEN+threadIdx.x];
+
+    const int num_blocks_k = K / BK;
+    int wg_idx = threadIdx.x / 128;
+    int tid = threadIdx.x % 128;
+
+    if (threadIdx.x == 0) {
+        for (int i = 0; i < QSIZE; ++i) {
+            init_barrier(&full[i], 0, 1);
+            init_barrier(&empty[i], 0, num_consumers*CLUSTERS);
+        }
+    }
+    asm volatile("barrier.cluster.arrive;\n" : :);
+    asm volatile("barrier.cluster.wait;\n" : :);
+
+
+    Schedule<2, NUM_SM/CLUSTERS, BM*CLUSTER_M, BN*CLUSTER_N, 16/CLUSTER_M, 8/CLUSTER_N> schedule(M, N, rank, &space[0]);
+
+    asm volatile("mov.u32 %0, %cluster_ctarank;\n" : "=r"(rank) :);
+    uint32_t rank_m = rank / CLUSTER_N;
+    uint32_t rank_n = rank % CLUSTER_N;
+
+    // Producer
+    if (wg_idx == 0) {
+        constexpr int num_regs = (num_consumers <= 2 ? 24 : 32);
+        warpgroup_reg_dealloc<num_regs>();
+        if (tid == 0) {
+            int p = 0;
+            int qidx = 0;
+            uint32_t col_mask = 0;
+            for (int i = 0; i < CLUSTER_M; ++i) {
+                col_mask |= (1 << (i * CLUSTER_N));
+            }
+            int num_block_m, num_block_n;
+            while (schedule.next(num_block_m, num_block_n)) {
+                num_block_n = num_block_n * CLUSTER_N + rank_n;
+                num_block_m = num_block_m * CLUSTER_M + rank_m;
+                
+                for (int block_k_iter = 0; block_k_iter < num_blocks_k; ++block_k_iter, ++qidx) {
+                    if (qidx == QSIZE) { qidx = 0; p ^= 1;}
+                    wait(&empty[qidx], p);
+                    
+                    expect_bytes(&full[qidx], (BK*BN+BK*BM)*sizeof(bf16));
+                    if constexpr (CLUSTER_N > 1) {
+                        uint32_t mask = ((1 << CLUSTER_N) - 1) << (rank_m * CLUSTER_N);
+                        if (rank_n == 0) {
+                            load_async_multicast(&sA[qidx*BK*BM], &tensorMapA, &full[qidx], block_k_iter*BK, num_block_m*BM, mask);
+                        }
+                    } else {
+                        load_async(&sA[qidx*BK*BM], &tensorMapA, &full[qidx], block_k_iter*BK, num_block_m*BM);
+                    }
+
+                    if constexpr (CLUSTER_M > 1) {
+                        if (rank_m == 0) {
+                            load_async_multicast(&sB[qidx*BK*BN], &tensorMapB, &full[qidx], block_k_iter*BK, num_block_n*BN, col_mask << rank_n);
+                        }
+                    } else {
+                        load_async(&sB[qidx*BK*BN], &tensorMapB, &full[qidx], block_k_iter*BK, num_block_n*BN);
+                    }
+                }
+            }
+        }
+    } else {
+        constexpr int num_regs = (num_consumers == 1 ? 256 : (num_consumers == 2 ? 240 : 160));
+        warpgroup_reg_alloc<num_regs>();
+        float d[B_WG_M/WGMMA_M][WGMMA_N/16][8];
+        --wg_idx;
+        for (int qidx = 0; qidx < QSIZE; ++qidx) {
+            if (tid < CLUSTERS) arrive_cluster(&empty[qidx], tid);
+        }
+        int p = 0;
+        int qidx = 0;
+        int num_block_m, num_block_n;
+
+        // stmatrix and wgmma layouts match for BF16:
+        // 1) 9.7.14.5.16 Warp-level matrix store instruction: stmatrix
+        // 2) Figure 148: WGMMA .m64nNk16 register fragment layout for accumulator matrix D
+        int lane = tid % 32, warp = tid / 32;
+        bf16* block_sC = sC + wg_idx*B_WG_M*BN;
+        uint32_t tid_offset = warp*16 + (lane % 8) * B_WG_M; // offset for x1 stmatrix
+        tid_offset += (lane/16)*B_WG_M*8 + (lane & 8); // row & column offsets for .x4 on stmatrix
+        uint32_t base_addr = static_cast<uint32_t>(__cvta_generic_to_shared(block_sC)) + tid_offset * sizeof(bf16);
+
+        while (schedule.next(num_block_m, num_block_n)) {
+            num_block_n = num_block_n * CLUSTER_N + rank_n;
+            num_block_m = num_block_m * CLUSTER_M + rank_m;
+            {
+                if (qidx == QSIZE) {qidx = 0; p ^= 1; };
+                wait(&full[qidx], p);
+                warpgroup_arrive();
+                #pragma unroll
+                for (int m_it = 0; m_it < B_WG_M/WGMMA_M; ++m_it) {
+                    bf16 *wgmma_sA = sA + qidx*BK*BM + 64*(m_it + wg_idx*B_WG_M/WGMMA_M)*WGMMA_M;
+                    bf16 *wgmma_sB = sB + qidx*BK*BN;
+                    {
+                        wgmma<WGMMA_N, 0, 1, 1, 0, 0>(d[m_it], &wgmma_sA[0], &wgmma_sB[0]);
+                        #pragma unroll
+                        for (int k_it = 1; k_it < 64/WGMMA_K; ++k_it) {
+                            wgmma<WGMMA_N, 1, 1, 1, 0, 0>(d[m_it], &wgmma_sA[k_it*WGMMA_K], &wgmma_sB[k_it*WGMMA_K]);
+                        }
+                        wgmma_sA += 64*BM;
+                        wgmma_sB += 64*BN;
+                    }
+                    #pragma unroll
+                    for (int bk = 64; bk < BK; bk += 64) {
+                        #pragma unroll
+                        for (int k_it = 0; k_it < 64/WGMMA_K; ++k_it) {
+                            wgmma<WGMMA_N, 1, 1, 1, 0, 0>(d[m_it], &wgmma_sA[k_it*WGMMA_K], &wgmma_sB[k_it*WGMMA_K]);
+                        }
+                        wgmma_sA += 64*BM;
+                        wgmma_sB += 64*BN;
+                    }
+                }
+                warpgroup_commit_batch();
+                warpgroup_wait();
+                if (tid < CLUSTERS) arrive_cluster(&empty[qidx], tid);
+                ++qidx;
+            }
+            for (int block_k_iter = 1; block_k_iter < num_blocks_k; ++block_k_iter, ++qidx) {
+                if (qidx == QSIZE) {qidx = 0; p ^= 1; };
+                wait(&full[qidx], p);
+                warpgroup_arrive();
+                #pragma unroll
+                for (int m_it = 0; m_it < B_WG_M/WGMMA_M; ++m_it) {
+                    bf16 *wgmma_sA = sA + qidx*BK*BM + 64*(m_it + wg_idx*B_WG_M/WGMMA_M)*WGMMA_M;
+                    bf16 *wgmma_sB = sB + qidx*BK*BN;
+                    #pragma unroll
+                    for (int bk = 0; bk < BK; bk += 64) {
+                        #pragma unroll
+                        for (int k_it = 0; k_it < 64/WGMMA_K; ++k_it) {
+                            wgmma<WGMMA_N, 1, 1, 1, 0, 0>(d[m_it], &wgmma_sA[k_it*WGMMA_K], &wgmma_sB[k_it*WGMMA_K]);
+                        }
+                        wgmma_sA += 64*BM;
+                        wgmma_sB += 64*BN;
+                    }
+                }
+                warpgroup_commit_batch();
+                warpgroup_wait();
+                if (tid < CLUSTERS) arrive_cluster(&empty[qidx], tid);
+            }
+
+            asm volatile("cp.async.bulk.wait_group 0;");
+            write_tile_tma<BM, BN, B_WG_M, WGMMA_M, WGMMA_N>(base_addr, (float*)d, block_sC, &tensorMapC, num_block_m, num_block_n, tid, wg_idx);
+        }
+    }
+}
+
+// Rotate/flip quadrant appropriately
+void rot(int n, int& x, int& y, int rx, int ry) {
+    if (ry == 0) {
+        if (rx == 1) {
+            x = n-1 - x;
+            y = n-1 - y;
+        }
+        // Swap x and y
+        int t = x;
+        x = y;
+        y = t;
+    }
+}
+
+// Convert distance along curve to (x,y) point
+void d2xy(int n, int d, int& x, int& y) {
+    int rx, ry, s, t = d;
+    x = y = 0;
+    for (s = 1; s < n; s *= 2) {
+        rx = 1 & (t/2);
+        ry = 1 & (t ^ rx);
+        rot(s, x, y, rx, ry);
+        x += s * rx;
+        y += s * ry;
+        t /= 4;
+    }
+}
+
+void createHilbert(int M, int N, int CORES, int *space) {
+    int dim = (1 << (32 - __builtin_clz(max(M, N) - 1)));
+    int core = 0;
+    std::vector<std::string> v(dim, std::string(dim, '.'));
+    memset(space, -1, sizeof(int)*CORES*SPACE_LEN);
+    int FCORES = 64;
+    int total = 0;
+    std::vector<std::vector<int>> pos(CORES, std::vector<int>());
+    for (int i = 0; i < dim*dim; ++i) {
+        int x, y;
+        d2xy(dim, i, x, y);
+        if (x < M && y < N) {
+            assert(loc < SPACE_LEN);
+            assert(v[x][y] == '.');
+            v[x][y] = '*';
+            ++total;
+            pos[core].push_back((x << 16) | y);
+            ++core;
+            if (core == FCORES) {core = 0;}
+        }
+    }
+    core = FCORES;
+    for (int i = 0; i < FCORES; ++i) {
+        if (pos.back().size() >= pos[0].size()-1) break;
+        pos[core].push_back(pos[i].back());
+        pos[i].pop_back();
+        ++core;
+        if (core == CORES) {core = FCORES;}
+    }
+    for (int i = 0; i < CORES; ++i) {
+        for (int j = 0; j < pos[i].size(); ++j) {
+            space[i*SPACE_LEN + j] = pos[i][j];
+        }
+    }
+    assert(total == M*N);
+}
+
+void runKernel12(int M, int N, int K, bf16 *A, bf16 *B, bf16 *C, int *DB) {
+    constexpr int BM = 128;
+    constexpr int BN = 256;
+    constexpr int BK = 64;
+    constexpr int NUM_THREADS = 128*3;
+    constexpr int QSIZE = 3;
+    constexpr int CLUSTER_M = 2;
+    constexpr int CLUSTER_N = 1;
+    constexpr int NUM_SM = 128;
+    constexpr int NUM_CONSUMERS = (NUM_THREADS / 128) - 1;
+    static_assert(NUM_SM % (CLUSTER_M*CLUSTER_N) == 0);
+
+    if (_prev_m != M) {
+        d_tma_map_A = create_tensor_map<BM, BK>(A, M, K);
+        d_tma_map_B = create_tensor_map<BN, BK>(B, N, K);
+        d_tma_map_C = create_tensor_map<BN, BM / NUM_CONSUMERS, false>(C, N, M);
+        _prev_m = M;
+        _prev_n = N;
+        _prev_k = K;
+        int *space;
+        space = (int*)malloc(sizeof(int)*NUM_SM*SPACE_LEN);
+        createHilbert(CEIL_DIV(M, BM*CLUSTER_M), CEIL_DIV(N, BN*CLUSTER_N), NUM_SM/CLUSTER_M/CLUSTER_N, space);
+        cudaCheck(cudaMalloc((void **)&_dspace, sizeof(int)*NUM_SM*SPACE_LEN));
+        cudaCheck(cudaMemcpy(_dspace, space, sizeof(int)*NUM_SM*SPACE_LEN, cudaMemcpyHostToDevice));
+    }
+    // Assert cached values are of same size
+    assert (M == _prev_m && N == _prev_n && K == _prev_k);
+    auto* kernel = matmulKernel11<BM, BN, BK, NUM_THREADS, QSIZE, NUM_SM, CLUSTER_M, CLUSTER_N>;
+    constexpr size_t sMemSize = sizeof(SMem<BM, BN, BK, QSIZE>);
+    static_assert(sMemSize < 256 * 1024);
+    cudaCheck(cudaFuncSetAttribute(
+        kernel,
+        cudaFuncAttributeMaxDynamicSharedMemorySize, sMemSize));
+
+    kernel<<<NUM_SM, NUM_THREADS, sMemSize>>>(M, N, K, d_tma_map_C, d_tma_map_A, d_tma_map_B, _dspace);
+}
+    
+} // namespace M12
+
+using M12::runKernel12;
+    

--- a/matmul.cu
+++ b/matmul.cu
@@ -38,6 +38,7 @@ void cudaCheck(cudaError_t error, const char *file, int line) {
 #include "examples/matmul/matmul_9.cuh"
 #include "examples/matmul/matmul_10.cuh"
 #include "examples/matmul/matmul_11.cuh"
+#include "examples/matmul/matmul_12.cuh"
 
 std::default_random_engine generator(69);
 cublasHandle_t cublas_handle;
@@ -90,6 +91,9 @@ void run_kernel(int kernel_num, int M, int N, int K, bf16 *A, bf16 *B, bf16 *C, 
       break;
     case 11:
       runKernel11(M, N, K, A, B, C, DB);
+      break;
+    case 12:
+      runKernel12(M, N, K, A, B, C, DB);
       break;
   }
 }
@@ -165,7 +169,7 @@ int main() {
 
   int repeat_times = 8;
   bool run_verif = true;
-  for (int kernel_num : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}) {
+  for (int kernel_num : {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}) {
     // for (int kernel_num : {0, 11}) {
     // Give the GPU some rest to avoid thermal throttling
     sleep(5);


### PR DESCRIPTION
This optimizes Kernel 11 by using the stmatrix PTX instruction: https://docs.nvidia.com/cuda/parallel-thread-execution/#warp-level-matrix-store-instruction-stmatrix

I had to add padding manually to avoid slow 8-way shared memory bank conflicts that made it not much faster than the original code (8 elements of padding per 64 M elements, so 12.5% padding for C!)

Also benefits from making the "bar.sync" between the shared memory writes and the TMA store per warpgroup to reduce unnecessary synchronisation (the TMA store is now per warpgroup instead of per threadgroup as well).

Same change we discussed earlier but it actually works this time... :)

---

GH200 96GiB performance at 705MHz:
cuBLAS --> 347.4
Kernel 11 --> 349.0
Kernel 12 --> 355.0 (+1.7%)

GH200 96GiB performance (unlocked clocks, 700W TDP):
cuBLAS --> ~683
Kernel 11 --> ~684
Kernel 12 --> ~690 (+0.9%)

Note: this is at the default 8192 kernel size, cuBLAS is a lot more competitive at 16384, but that might just be because the supertile sizes and other hyperparams don't fit 16384 as well(?)

---

SASS is now extremely clean for that part of the kernel!

[...]
F2FP.BF16.F32.PACK_AB R82, R85, R84
F2FP.BF16.F32.PACK_AB R83, R87, R86
F2FP.BF16.F32.PACK_AB R89, R91, R90
F2FP.BF16.F32.PACK_AB R96, R97, R96
STSM.16.MT88.4 [R6+0x1f800], R80
F2FP.BF16.F32.PACK_AB R90, R93, R92
F2FP.BF16.F32.PACK_AB R91, R95, R94
F2FP.BF16.F32.PACK_AB R97, R99, R98
F2FP.BF16.F32.PACK_AB R104, R105, R104
STSM.16.MT88.4 [R6+0x20000], R88
[...]