### PR TITLE
No need to zero init out registers

### DIFF
--- a/examples/matmul/matmul_9.cuh
+++ b/examples/matmul/matmul_9.cuh
@@ -471,7 +471,6 @@ __global__  __launch_bounds__(NUM_THREADS) void  __cluster_dims__(CLUSTER_M * CL
         while (schedule.next(num_block_m, num_block_n)) {
             num_block_n = num_block_n * CLUSTER_N + rank_n;
             num_block_m = num_block_m * CLUSTER_M + rank_m;
-            memset(d, 0, sizeof(d));
             {
                 if (qidx == QSIZE) {qidx = 0; p ^= 1; };
                 wait(&full[qidx], p);


### PR DESCRIPTION
memset of `d` is redundant as matmul takes the shape D = A*B so we don't care about the initial values.