### PR TITLE
Hilbert kernel: Reduce space for space len, remove spurious assert

### DIFF
--- a/examples/matmul/matmul_11.cuh
+++ b/examples/matmul/matmul_11.cuh
@@ -303,7 +303,7 @@ __device__ static inline void load_async_multicast(bf16 *dst, void const* src_tm
 template<int VERSION, int NUM_SM, int BM, int BN, int TM, int TN>
 struct Schedule;
 
-constexpr int SPACE_LEN = 128;
+constexpr int SPACE_LEN = 16;
 int *_dspace;
 
 template<int NUM_SM, int BM, int BN, int TM, int TN>
@@ -572,7 +572,6 @@ void createHilbert(int M, int N, int CORES, int *space) {
         int x, y;
         d2xy(dim, i, x, y);
         if (x < M && y < N) {
-            assert(loc < SPACE_LEN);
             assert(v[x][y] == '.');
             v[x][y] = '*';
             ++total;


### PR DESCRIPTION
We're allocating too much space for SPACE_LEN.

With SPACE_LEN = 16 we support all the way up to 8192x8192 output matrix assuming we don't change the effective BMxBN (256x256) tile size (BM = 128 but with cluster size along M dimension of 2 it's 256 effective).